### PR TITLE
ffmpeg: disable MediaFoundation support / wrapper for Win10 Pro N

### DIFF
--- a/mingw-w64-ffmpeg/PKGBUILD
+++ b/mingw-w64-ffmpeg/PKGBUILD
@@ -130,6 +130,7 @@ build() {
     --enable-vulkan
     --enable-zlib
     --disable-doc
+    --disable-mediafoundation
     --build-suffix=-if
   )
 


### PR DESCRIPTION
Changes:

* Disable the media foundation support for new builds.

Details:

With the mediafoundation wrapper support enabled it will crash on
loading libavcodec on systems where there is no Media Feature Pack
installed.

Windows 10/11 Pro N doesn't have the [media feature pack](https://www.microsoft.com/en-us/software-download/mediafeaturepack)
